### PR TITLE
Osutrack on welcome

### DIFF
--- a/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
@@ -74,6 +74,7 @@ import tillerino.tillerinobot.handlers.WithHandler;
 import tillerino.tillerinobot.lang.Default;
 import tillerino.tillerinobot.lang.Language;
 import tillerino.tillerinobot.osutrack.OsutrackDownloader;
+import tillerino.tillerinobot.osutrack.UpdateResult;
 import tillerino.tillerinobot.rest.BotInfoService.BotInfo;
 
 @Slf4j
@@ -115,6 +116,7 @@ public class IRCBot extends CoreHooks implements TidyObject {
 	final ThreadLocalAutoCommittingEntityManager em;
 	final EntityManagerFactory emf;
 	final IrcNameResolver resolver;
+	final OsutrackDownloader osutrackDownloader;
 	
 	@Inject
 	public IRCBot(BotBackend backend, RecommendationsManager manager,
@@ -131,6 +133,7 @@ public class IRCBot extends CoreHooks implements TidyObject {
 		this.em = em;
 		this.emf = emf;
 		this.resolver = resolver;
+		this.osutrackDownloader = osutrackDownloader;
 		
 		commandHandlers.add(new ResetHandler(manager));
 		commandHandlers.add(new OptionsHandler(manager));
@@ -610,6 +613,12 @@ public class IRCBot extends CoreHooks implements TidyObject {
 				Response welcome = data.getLanguage().welcomeUser(apiUser,
 						inactiveTime);
 				sendResponse(welcome, user);
+
+				if (data.isDoOsuTrackUpdateOnWelcome()) {
+					UpdateResult update = osutrackDownloader.getUpdate(user.getNick());
+					Response updateResponse = OsuTrackHandler.UpdateResultToResponse(update);
+					sendResponse(updateResponse, user);
+				}
 				
 				checkVersionInfo(user);
 			}

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
@@ -616,7 +616,7 @@ public class IRCBot extends CoreHooks implements TidyObject {
 
 				if (data.isDoOsuTrackUpdateOnWelcome()) {
 					UpdateResult update = osutrackDownloader.getUpdate(user.getNick());
-					Response updateResponse = OsuTrackHandler.UpdateResultToResponse(update);
+					Response updateResponse = OsuTrackHandler.updateResultToResponse(update);
 					sendResponse(updateResponse, user);
 				}
 				

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
@@ -614,7 +614,7 @@ public class IRCBot extends CoreHooks implements TidyObject {
 						inactiveTime);
 				sendResponse(welcome, user);
 
-				if (data.isDoOsuTrackUpdateOnWelcome()) {
+				if (data.isOsuTrackWelcomeEnabled()) {
 					UpdateResult update = osutrackDownloader.getUpdate(user.getNick());
 					Response updateResponse = OsuTrackHandler.updateResultToResponse(update);
 					sendResponse(updateResponse, user);

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/UserDataManager.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/UserDataManager.java
@@ -224,6 +224,14 @@ public class UserDataManager extends AbstractMBeanRegistration implements UserDa
 			changed |= welcomeMessage != this.showWelcomeMessage;
 			this.showWelcomeMessage = welcomeMessage;
 		}
+
+		@Getter
+		boolean doOsuTrackUpdateOnWelcome = false;
+
+		public void setDoOsuTrackUpdateOnWelcome(boolean doOsuTrackUpdateOnWelcome) {
+			changed |= doOsuTrackUpdateOnWelcome != this.doOsuTrackUpdateOnWelcome;
+			this.doOsuTrackUpdateOnWelcome = doOsuTrackUpdateOnWelcome;
+		}
 	}
 	
 	final BotBackend backend;

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/UserDataManager.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/UserDataManager.java
@@ -226,11 +226,11 @@ public class UserDataManager extends AbstractMBeanRegistration implements UserDa
 		}
 
 		@Getter
-		boolean doOsuTrackUpdateOnWelcome = false;
+		boolean osuTrackWelcomeEnabled = false;
 
-		public void setDoOsuTrackUpdateOnWelcome(boolean doOsuTrackUpdateOnWelcome) {
-			changed |= doOsuTrackUpdateOnWelcome != this.doOsuTrackUpdateOnWelcome;
-			this.doOsuTrackUpdateOnWelcome = doOsuTrackUpdateOnWelcome;
+		public void setOsuTrackWelcomeEnabled(boolean doOsuTrackUpdateOnWelcome) {
+			changed |= doOsuTrackUpdateOnWelcome != this.osuTrackWelcomeEnabled;
+			this.osuTrackWelcomeEnabled = doOsuTrackUpdateOnWelcome;
 		}
 	}
 	

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OptionsHandler.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OptionsHandler.java
@@ -83,6 +83,12 @@ public class OptionsHandler implements CommandHandler {
 			} else {
 				return new Message("Welcome Message: " + (userData.isShowWelcomeMessage() ? "ON" : "OFF"));
 			}
+		} else if (getLevenshteinDistance(option, "osutrack") <= 1 && userData.getHearts() > 0) {
+			if (set) {
+				userData.setDoOsuTrackUpdateOnWelcome(parseBoolean(value, userData.getLanguage()));
+			} else {
+				return new Message("osu!track on welcome: " + (userData.isDoOsuTrackUpdateOnWelcome() ? "ON" : "OFF"));
+			}
 		} else if (getLevenshteinDistance(option, "default") <= 1) {
 			if (set) {
 				if (value.isEmpty()) {

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OptionsHandler.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OptionsHandler.java
@@ -83,11 +83,11 @@ public class OptionsHandler implements CommandHandler {
 			} else {
 				return new Message("Welcome Message: " + (userData.isShowWelcomeMessage() ? "ON" : "OFF"));
 			}
-		} else if (getLevenshteinDistance(option, "osutrack") <= 1 && userData.getHearts() > 0) {
+		} else if (getLevenshteinDistance(option, "osutrack-welcome") <= 1 && userData.getHearts() > 0) {
 			if (set) {
-				userData.setDoOsuTrackUpdateOnWelcome(parseBoolean(value, userData.getLanguage()));
+				userData.setOsuTrackWelcomeEnabled(parseBoolean(value, userData.getLanguage()));
 			} else {
-				return new Message("osu!track on welcome: " + (userData.isDoOsuTrackUpdateOnWelcome() ? "ON" : "OFF"));
+				return new Message("osu!track on welcome: " + (userData.isOsuTrackWelcomeEnabled() ? "ON" : "OFF"));
 			}
 		} else if (getLevenshteinDistance(option, "default") <= 1) {
 			if (set) {

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OptionsHandler.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OptionsHandler.java
@@ -37,6 +37,8 @@ public class OptionsHandler implements CommandHandler {
 		} else if (command.toLowerCase().startsWith("show")
 				|| command.toLowerCase().startsWith("view")) {
 			command = command.substring("show".length()).trim();
+		} else if (command.toLowerCase().startsWith("get")) {
+			command = command.substring("get".length()).trim();
 		} else {
 			return null;
 		}

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OsuTrackHandler.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OsuTrackHandler.java
@@ -31,6 +31,10 @@ public class OsuTrackHandler extends CommandHandler.WithShorthand {
         String username = remaining.isEmpty() ? apiUser.getUserName() : remaining.trim();
         UpdateResult update = osutrackDownloader.getUpdate(username);
 
+        return UpdateResultToResponse(update);
+    }
+
+    public static Response UpdateResultToResponse(UpdateResult update) {
         if (!update.isExists()) {
             return new Success(String.format("The user %s can't be found.  Try replaced spaces with underscores and try again.", update.getUsername()));
         }

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OsuTrackHandler.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/handlers/OsuTrackHandler.java
@@ -31,10 +31,10 @@ public class OsuTrackHandler extends CommandHandler.WithShorthand {
         String username = remaining.isEmpty() ? apiUser.getUserName() : remaining.trim();
         UpdateResult update = osutrackDownloader.getUpdate(username);
 
-        return UpdateResultToResponse(update);
+        return updateResultToResponse(update);
     }
 
-    public static Response UpdateResultToResponse(UpdateResult update) {
+    public static Response updateResultToResponse(UpdateResult update) {
         if (!update.isExists()) {
             return new Success(String.format("The user %s can't be found.  Try replaced spaces with underscores and try again.", update.getUsername()));
         }


### PR DESCRIPTION
add a user-option to have a osutrack update automatically send to you alongside the donator welcome message.

I need this in my life :stuck_out_tongue_winking_eye: 

Some questions:
* Does "just" adding the boolean variable to the UserData class do the job? Or does that mess up shit somewhere else..
* I needed a way to get a "response" object in the welcome thingy, so hence the static `UpdateResultToResponse` method. Not sure if I like it this way, but I dunno where else to put it, and this works so why not :stuck_out_tongue:. Thoughts?
* The option parameter to use to change this setting is `osutrack`, which doesnt really describe what it does, but `osutrack-on-welcome` or something is kinda long and annoying to type.. Thoughts?
