### PR TITLE
check for mismatch between irc user and api user and repair mapping if needed

### DIFF
--- a/tillerinobot/src/main/java/tillerino/tillerinobot/data/UserNameMapping.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/data/UserNameMapping.java
@@ -3,14 +3,25 @@ package tillerino.tillerinobot.data;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
+import org.tillerino.osuApiModel.types.UserId;
+
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import tillerino.tillerinobot.BotBackend.IRCName;
 
 @Entity(name = "usernames")
 @Data
 public class UserNameMapping {
 	@Id
+	@IRCName
+	@Getter(onMethod = @__(@IRCName))
+	@Setter(onParam = @__(@IRCName))
 	private String userName;
 
+	@UserId
+	@Getter(onMethod = @__(@UserId))
+	@Setter(onParam = @__(@UserId))
 	private int userid;
 
 	private long resolved;


### PR DESCRIPTION
why not detect if a irc username doesnt match the api user object and if a mismatch is detected we have two broken mappens:
1. the api user object (aka the userid) belongs to a different username
2. the username belongs to a different api user object (aka different userid)

both are fixable