### PR TITLE
new pp

### DIFF
--- a/tillerinobot-irc/src/main/java/org/tillerino/ppaddict/chat/irc/IrcHooks.java
+++ b/tillerinobot-irc/src/main/java/org/tillerino/ppaddict/chat/irc/IrcHooks.java
@@ -139,6 +139,7 @@ public class IrcHooks extends CoreHooks {
 	}
 
 	@Override
+	@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "looks like a bug")
 	public void onEvent(Event event) throws Exception {
 		botInfo.setLastInteraction(timestamp(event));
 		MDC.clear();

--- a/tillerinobot-model/src/main/java/org/tillerino/ppaddict/chat/GameChatResponse.java
+++ b/tillerinobot-model/src/main/java/org/tillerino/ppaddict/chat/GameChatResponse.java
@@ -60,6 +60,7 @@ public interface GameChatResponse {
 	/**
 	 * Adds another response to the current one.
 	 */
+	@SuppressFBWarnings("SA_LOCAL_SELF_COMPARISON")
 	default GameChatResponse then(@CheckForNull GameChatResponse nextResponse) {
 		if (nextResponse instanceof NoResponse || nextResponse == null) {
 			return this;

--- a/tillerinobot/src/main/java/org/tillerino/ppaddict/chat/impl/MessagePreprocessor.java
+++ b/tillerinobot/src/main/java/org/tillerino/ppaddict/chat/impl/MessagePreprocessor.java
@@ -43,7 +43,7 @@ public class MessagePreprocessor implements GameChatEventConsumer {
 	private final Clock clock;
 
 	@Override
-	@SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE", justification = "For the try-with. Looks like this is a Java 13 bug in Spotbugs 3.1.11")
+	@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "Looks like a bug")
 	public void onEvent(GameChatEvent event) throws InterruptedException {
 		try (MdcAttributes mdc = MdcUtils.with(MdcUtils.MDC_EVENT, event.getEventId())) {
 			mdc.add(MdcUtils.MDC_USER, event.getNick());

--- a/tillerinobot/src/main/java/org/tillerino/ppaddict/chat/impl/ResponsePostprocessor.java
+++ b/tillerinobot/src/main/java/org/tillerino/ppaddict/chat/impl/ResponsePostprocessor.java
@@ -21,6 +21,7 @@ import org.tillerino.ppaddict.util.MdcUtils;
 import org.tillerino.ppaddict.util.RetryableException;
 import org.tillerino.ppaddict.util.MdcUtils.MdcAttributes;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -64,6 +65,7 @@ public class ResponsePostprocessor implements GameChatResponseConsumer {
 		}
 	}
 
+	@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "Looks like a bug")
 	private void handleResponse(GameChatResponse response, GameChatEvent result) throws InterruptedException, IOException {
 		if (response instanceof Message message) {
 			message(message.getContent(), false, result);

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/IRCBot.java
@@ -320,6 +320,7 @@ public class IRCBot implements GameChatEventConsumer {
 		}
 	}
 
+	@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "Looks like a bug")
 	private GameChatResponse visit(GameChatEvent event) throws SQLException, InterruptedException, IOException, UserException {
 		if (event instanceof Joined) {
 			try {

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/UserDataManager.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/UserDataManager.java
@@ -45,6 +45,7 @@ import tillerino.tillerinobot.util.IsMutable;
  * @author Tillerino
  */
 @Singleton
+@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "Looks like a bug")
 public class UserDataManager {
 	/**
 	 * Bot-specific user data. It is only saved when changed and responsible for
@@ -53,6 +54,8 @@ public class UserDataManager {
 	 * 
 	 * @author Tillerino
 	 */
+
+	@SuppressFBWarnings(value = "SA_FIELD_SELF_COMPARISON", justification = "Looks like a bug")
 	public static class UserData implements Closeable {
 		public record BeatmapWithMods(@BeatmapId int beatmap, @BitwiseMods long mods) { }
 

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/diff/Beatmap.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/diff/Beatmap.java
@@ -1,10 +1,12 @@
 package tillerino.tillerinobot.diff;
 
+import static org.tillerino.osuApiModel.Mods.TouchDevice;
 import static org.tillerino.osuApiModel.Mods.DoubleTime;
 import static org.tillerino.osuApiModel.Mods.Easy;
 import static org.tillerino.osuApiModel.Mods.HalfTime;
 import static org.tillerino.osuApiModel.Mods.HardRock;
 import static org.tillerino.osuApiModel.Mods.Nightcore;
+import static org.tillerino.osuApiModel.Mods.Hidden;
 import static org.tillerino.osuApiModel.Mods.getMask;
 
 import org.tillerino.osuApiModel.Mods;
@@ -32,10 +34,10 @@ public interface Beatmap {
 	public static final int SpeedNoteCount = 7;
 
 	@BitwiseMods
-	static long diffMods = getMask(HalfTime, DoubleTime, Easy, HardRock, Mods.Flashlight);
+	static long diffMods = getMask(TouchDevice, HalfTime, DoubleTime, Easy, HardRock, Mods.Flashlight);
 
 	/**
-	 * returns only HT, DT, EZ, HR, and FL, converting NC to DT
+	 * returns only TD, HT, DT, EZ, HR, and FL, converting NC to DT. Also includes HD, but only if FL is present
 	 * @param mods
 	 * @return
 	 */
@@ -46,7 +48,14 @@ public interface Beatmap {
 			mods ^= getMask(Nightcore);
 		}
 
+		boolean hdfl = Mods.Flashlight.is(mods) && Hidden.is(mods);
+
 		mods = mods & diffMods;
+
+		if(hdfl) {
+			// re-apply HD if used in combination with FL
+			mods |= getMask(Hidden);
+		}
 
 		return mods;
 	}

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/diff/Beatmap.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/diff/Beatmap.java
@@ -29,6 +29,7 @@ public interface Beatmap {
 	public static final int MaxCombo = 4;
 	public static final int SliderFactor = 5;
 	public static final int Flashlight = 6;
+	public static final int SpeedNoteCount = 7;
 
 	@BitwiseMods
 	static long diffMods = getMask(HalfTime, DoubleTime, Easy, HardRock, Mods.Flashlight);

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/diff/BeatmapImpl.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/diff/BeatmapImpl.java
@@ -22,14 +22,12 @@ public class BeatmapImpl implements Beatmap {
 	private float starDiff;
 	private float aim;
 	private float speed;
-	private float flashlight;
-
-	private float sliderFactor;
-
-	private float approachRate;
 	private float overallDifficulty;
-
+	private float approachRate;
 	private int maxCombo;
+	private float sliderFactor;
+	private float flashlight;
+	private float speedNoteCount;
 
 	private int circleCount;
 	private int spinnerCount;
@@ -43,12 +41,13 @@ public class BeatmapImpl implements Beatmap {
 
 		return switch (kind) {
 			case Beatmap.Aim -> aim;
-			case Beatmap.AR -> approachRate;
-			case Beatmap.Flashlight -> flashlight;
-			case Beatmap.MaxCombo -> maxCombo;
-			case Beatmap.OD -> overallDifficulty;
-			case Beatmap.SliderFactor -> sliderFactor;
 			case Beatmap.Speed -> speed;
+			case Beatmap.OD -> overallDifficulty;
+			case Beatmap.AR -> approachRate;
+			case Beatmap.MaxCombo -> maxCombo;
+			case Beatmap.SliderFactor -> sliderFactor;
+			case Beatmap.Flashlight -> flashlight;
+			case Beatmap.SpeedNoteCount -> speedNoteCount;
 			default -> throw new IllegalArgumentException("Unexpected kind: " + kind);
 		};
 	}

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/diff/sandoku/SanDoku.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/diff/sandoku/SanDoku.java
@@ -31,7 +31,7 @@ public interface SanDoku {
 	/**
 	 * Once changes in SanDoku have been deployed and values need to be recalculated, bump this version!
 	 */
-	final int VERSION = 1;
+	final int VERSION = 2;
 
 	@POST
 	@Path("/diff")

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/diff/sandoku/SanDokuResponse.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/diff/sandoku/SanDokuResponse.java
@@ -19,15 +19,16 @@ public record SanDokuResponse(
 	@Builder(toBuilder = true)
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static record SanDokuDiffCalcResult(
-		// removed fields which are not required for standard
-		double starRating,
+		// only declare fields which are needed for std calc
 		int maxCombo,
-		double aimStrain,
-		double speedStrain,
-		double flashlightRating,
-		double sliderFactor,
-		double approachRate,
+		double starRating,
+		double aim,
+		double speed,
 		double overallDifficulty,
+		double approachRate,
+		double flashlight,
+		double sliderFactor,
+		double speedNoteCount,
 		int hitCircleCount,
 		int sliderCount,
 		int spinnerCount) {
@@ -35,17 +36,19 @@ public record SanDokuResponse(
 
 	public BeatmapImpl toBeatmap() {
 		return BeatmapImpl.builder()
-				.aim((float) diffCalcResult.aimStrain)
-				.approachRate((float) diffCalcResult.approachRate)
-				.circleCount(diffCalcResult.hitCircleCount)
-				.flashlight((float) diffCalcResult.flashlightRating)
-				.maxCombo(diffCalcResult.maxCombo)
 				.modsUsed(modsUsed)
-				.overallDifficulty((float) diffCalcResult.overallDifficulty)
-				.sliderCount(diffCalcResult.sliderCount)
-				.speed((float) diffCalcResult.speedStrain)
-				.spinnerCount(diffCalcResult.spinnerCount)
 				.starDiff((float) diffCalcResult.starRating)
+				.aim((float) diffCalcResult.aim)
+				.speed((float) diffCalcResult.speed)
+				.overallDifficulty((float) diffCalcResult.overallDifficulty)
+				.approachRate((float) diffCalcResult.approachRate)
+				.maxCombo(diffCalcResult.maxCombo)
+				.sliderFactor((float) diffCalcResult.sliderFactor)
+				.flashlight((float) diffCalcResult.flashlight)
+				.speedNoteCount((float) diffCalcResult.speedNoteCount)
+				.circleCount(diffCalcResult.hitCircleCount)
+				.spinnerCount(diffCalcResult.spinnerCount)
+				.sliderCount(diffCalcResult.sliderCount)
 				.build();
 	}
 }

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/predicates/NumericPropertyPredicate.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/predicates/NumericPropertyPredicate.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 
 import org.tillerino.osuApiModel.OsuApiBeatmap;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 @Value
 public class NumericPropertyPredicate<T extends NumericBeatmapProperty>
 		implements RecommendationPredicate {
@@ -35,6 +37,7 @@ public class NumericPropertyPredicate<T extends NumericBeatmapProperty>
 	}
 
 	@Override
+	@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "Looks like a bug")
 	public boolean contradicts(RecommendationPredicate otherPredicate) {
 		if (otherPredicate instanceof NumericPropertyPredicate<?> predicate
 				&& predicate.property.getClass() == property.getClass()) {

--- a/tillerinobot/src/main/java/tillerino/tillerinobot/rest/RestUtils.java
+++ b/tillerinobot/src/main/java/tillerino/tillerinobot/rest/RestUtils.java
@@ -6,6 +6,8 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 public final class RestUtils {
 	private RestUtils() {
 		// utils class
@@ -19,6 +21,7 @@ public final class RestUtils {
 		return new WebApplicationException("The server is being shutdown for maintenance", Status.SERVICE_UNAVAILABLE);
 	}
 
+	@SuppressFBWarnings(value = "SA_LOCAL_SELF_COMPARISON", justification = "Looks like a bug")
 	public static Throwable refreshWebApplicationException(Throwable t) {
 		if (t instanceof WebApplicationException web) {
 			return new WebApplicationException(t.getCause(), Response.fromResponse(web.getResponse()).build());

--- a/tillerinobot/src/test/java/tillerino/tillerinobot/BeatmapMetaTest.java
+++ b/tillerinobot/src/test/java/tillerino/tillerinobot/BeatmapMetaTest.java
@@ -15,12 +15,12 @@ public class BeatmapMetaTest {
 	public void testFuturePpSwitch() throws Exception {
 		BeatmapMeta meta = fakeBeatmapMeta(101);
 		assertEquals(
-				"[http://osu.ppy.sh/b/69 Artist - Title [Version]] DT   future you: 100pp | 95%: 29pp | 98%: 60pp | 99%: 77pp | 100%: 101pp | 1:14 ★ 2.68 ♫ 630 AR10.33 OD9.08",
+				"[http://osu.ppy.sh/b/69 Artist - Title [Version]] DT   future you: 100pp | 95%: 31pp | 98%: 60pp | 99%: 77pp | 100%: 101pp | 1:14 ★ 2.68 ♫ 630 AR10.33 OD9.08",
 				meta.formInfoMessage(true, null, -1, null, null, null));
 
 		meta = fakeBeatmapMeta(110);
 		assertEquals(
-				"[http://osu.ppy.sh/b/69 Artist - Title [Version]] DT   95%: 29pp | 98%: 60pp | 99%: 77pp | 100%: 101pp | 1:14 ★ 2.68 ♫ 630 AR10.33 OD9.08",
+				"[http://osu.ppy.sh/b/69 Artist - Title [Version]] DT   95%: 31pp | 98%: 60pp | 99%: 77pp | 100%: 101pp | 1:14 ★ 2.68 ♫ 630 AR10.33 OD9.08",
 				meta.formInfoMessage(true, null, -1, null, null, null));
 	}
 
@@ -38,7 +38,7 @@ public class BeatmapMetaTest {
 		BeatmapImpl cBeatmap = BeatmapImpl.builder()
 				.modsUsed(64)
 				.speed(1.45f)
-				.aim(1f)
+				.aim(1.45f)
 				.circleCount(200)
 				.sliderCount(40)
 				.spinnerCount(10)

--- a/tillerinobot/src/test/java/tillerino/tillerinobot/diff/sandoku/SanDokuTestManual.java
+++ b/tillerinobot/src/test/java/tillerino/tillerinobot/diff/sandoku/SanDokuTestManual.java
@@ -38,29 +38,37 @@ public class SanDokuTestManual {
 		byte[] beatmap = IOUtils.resourceToByteArray("/Fujijo Seitokai Shikkou-bu - Best FriendS -TV Size- (Flask) [Fycho's Insane].osu");
 
 		assertThat(sanDoku.getDiff(0, 0, beatmap).diffCalcResult()).satisfies(result -> {
-			assertThat(result.starRating()).isCloseTo(4.70888, apiRounding);
-			assertThat(result.aimStrain()).isCloseTo(2.53559, apiRounding);
-			assertThat(result.speedStrain()).isCloseTo(1.89119, apiRounding);
+			// https://osu.ppy.sh/api/get_beatmaps?k=***&m=0&b=328472&mods=0
+			assertThat(result.starRating()).isCloseTo(4.73447, apiRounding);
+			assertThat(result.aim()).isCloseTo(2.53878, apiRounding);
+			assertThat(result.speed()).isCloseTo(1.88141, apiRounding);
+			assertThat(result.maxCombo()).isEqualTo(404);
 		});
 
 		// Flashlight
 		assertThat(sanDoku.getDiff(0, 1024, beatmap).diffCalcResult()).satisfies(result -> {
-			assertThat(result.starRating()).isCloseTo(5.23327, apiRounding); // star rating is different!
-			assertThat(result.aimStrain()).isCloseTo(2.53559, apiRounding);
-			assertThat(result.speedStrain()).isCloseTo(1.89119, apiRounding);
+			// https://osu.ppy.sh/api/get_beatmaps?k=***&m=0&b=328472&mods=1024
+			assertThat(result.starRating()).isCloseTo(5.28149, apiRounding); // star rating is different!
+			assertThat(result.aim()).isCloseTo(2.53878, apiRounding);
+			assertThat(result.speed()).isCloseTo(1.88141, apiRounding);
+			assertThat(result.maxCombo()).isEqualTo(404);
 		});
 
 		assertThat(sanDoku.getDiff(0, 64, beatmap).diffCalcResult()).satisfies(result -> {
-			assertThat(result.starRating()).isCloseTo(6.62106, apiRounding);
-			assertThat(result.aimStrain()).isCloseTo(3.52118, apiRounding);
-			assertThat(result.speedStrain()).isCloseTo(2.7438, apiRounding);
+			// https://osu.ppy.sh/api/get_beatmaps?k=***&m=0&b=328472&mods=64
+			assertThat(result.starRating()).isCloseTo(6.65472, apiRounding);
+			assertThat(result.aim()).isCloseTo(3.52504, apiRounding);
+			assertThat(result.speed()).isCloseTo(2.72927, apiRounding);
+			assertThat(result.maxCombo()).isEqualTo(404);
 		});
 
 		// now with HR DT
 		assertThat(sanDoku.getDiff(0, 80, beatmap).diffCalcResult()).satisfies(result -> {
-			assertThat(result.starRating()).isCloseTo(7.03281, apiRounding);
-			assertThat(result.aimStrain()).isCloseTo(3.82381, apiRounding);
-			assertThat(result.speedStrain()).isCloseTo(2.75015, apiRounding);
+			// https://osu.ppy.sh/api/get_beatmaps?k=***&m=0&b=328472&mods=80
+			assertThat(result.starRating()).isCloseTo(7.06681, apiRounding);
+			assertThat(result.aim()).isCloseTo(3.82241, apiRounding);
+			assertThat(result.speed()).isCloseTo(2.74129, apiRounding);
+			assertThat(result.maxCombo()).isEqualTo(404);
 		});
 	}
 
@@ -78,12 +86,12 @@ public class SanDokuTestManual {
 		score.setCountMiss(0);
 		score.setMods(Mods.getMask(Mods.Hidden, Mods.HardRock, Mods.DoubleTime));
 		OsuScore standardScore = new OsuScore(score);
-		assertThat(standardScore.getPP(diff.toBeatmap())).isCloseTo(552.222f, webRounding);
+		assertThat(standardScore.getPP(diff.toBeatmap())).isCloseTo(560.049f, webRounding);
 	}
 
 	@Test
 	public void testBestFriendsTemaZpro() throws Exception {
-		// https://osu.ppy.sh/scores/osu/2111593239
+		// https://osu.ppy.sh/scores/osu/3939515677
 		byte[] beatmap = IOUtils.resourceToByteArray("/Fujijo Seitokai Shikkou-bu - Best FriendS -TV Size- (Flask) [Fycho's Insane].osu");
 		SanDokuResponse diff = sanDoku.getDiff(0, Mods.getMask(Mods.DoubleTime), beatmap);
 
@@ -93,9 +101,9 @@ public class SanDokuTestManual {
 		score.setCount100(0);
 		score.setCount50(0);
 		score.setCountMiss(0);
-		score.setMods(Mods.getMask(Mods.Hidden, Mods.Nightcore));
+		score.setMods(Mods.getMask(Mods.Hidden, Mods.DoubleTime, Mods.Nightcore));
 		OsuScore standardScore = new OsuScore(score);
-		assertThat(standardScore.getPP(diff.toBeatmap())).isCloseTo(373.611f, webRounding);
+		assertThat(standardScore.getPP(diff.toBeatmap())).isCloseTo(379.488f, webRounding);
 	}
 
 	@Test
@@ -104,11 +112,14 @@ public class SanDokuTestManual {
 		SanDokuResponse diff = sanDoku.getDiff(0, 0, beatmap);
 
 		assertThat(diff.diffCalcResult()).satisfies(result -> {
-			assertThat(result.starRating()).isCloseTo(7.52382, apiRounding);
-			assertThat(result.aimStrain()).isCloseTo(3.45227, apiRounding);
-			assertThat(result.speedStrain()).isCloseTo(3.77577, apiRounding);
+			// https://osu.ppy.sh/api/get_beatmaps?k=***&m=0&b=129891&mods=0
+			assertThat(result.starRating()).isCloseTo(7.58325, apiRounding);
+			assertThat(result.aim()).isCloseTo(3.47299, apiRounding);
+			assertThat(result.speed()).isCloseTo(3.77182, apiRounding);
+			assertThat(result.maxCombo()).isEqualTo(2385);
 		});
 
+		// https://osu.ppy.sh/scores/osu/2355338302
 		OsuApiScore score = new OsuApiScore();
 		score.setMaxCombo(2385);
 		score.setCount300(1981);
@@ -117,7 +128,7 @@ public class SanDokuTestManual {
 		score.setCountMiss(0);
 		score.setMods(0);
 		OsuScore standardScore = new OsuScore(score);
-		assertThat(standardScore.getPP(diff.toBeatmap())).isCloseTo(612.754f, webRounding);
+		assertThat(standardScore.getPP(diff.toBeatmap())).isCloseTo(626.636f, webRounding);
 	}
 
 	@Test

--- a/tillerinobot/src/test/java/tillerino/tillerinobot/diff/sandoku/SanDokuTestManual.java
+++ b/tillerinobot/src/test/java/tillerino/tillerinobot/diff/sandoku/SanDokuTestManual.java
@@ -3,7 +3,6 @@ package tillerino.tillerinobot.diff.sandoku;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Ported over https://github.com/ppy/osu-performance/blob/2022.929.0/src/performance/osu/OsuScore.cpp and adjusted SanDuko.

To run it requires the new version of SanDoku, currently in this branch: https://github.com/omkelderman/SanDoku/tree/new-sr-and-pp

The only pp related test that still currently fails is testBestFriendsTemaZpro:
```
java.lang.AssertionError: 
Expecting actual:
  379.49088f
to be close to:
  379.488f
by less than 0.002f but difference was 0.00288f.
(a difference of exactly 0.002f being considered valid)
```

The difference is so incredibly small that I think this is due to web-pp being calculated by a process that uses ever so slightly different rounding or whatever the fuck. If I run the pp calc in SanDoku I get a PP value of **379.4909879714523** which is every so slightly different *again* so uhm, ye idk.

Other notable test that fails is testFuturePpSwitch in BeatmapMetaTest, but I have no idea what exactly is happening there so I'll leave that to you to fix. Do note that a new diff-attribute was introduced (SpeedNoteCount, which confusingly is not an integer but a float, and yes its also being used as such in calc, dont ask me why) so you might wanna introduce that one as well in ur fake beatmap in `fakeBeatmapMeta`?